### PR TITLE
Fix how the List bubble implementation decides which items are visible

### DIFF
--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
@@ -6,7 +6,6 @@ import static com.williamcallahan.tui4j.compat.bubbletea.Command.batch;
 import com.williamcallahan.tui4j.ansi.Truncate;
 import com.williamcallahan.tui4j.compat.bubbles.help.Help;
 import com.williamcallahan.tui4j.compat.bubbles.key.Binding;
-import com.williamcallahan.tui4j.compat.bubbles.list.KeyMap;
 import com.williamcallahan.tui4j.compat.bubbles.paginator.Paginator;
 import com.williamcallahan.tui4j.compat.bubbles.paginator.Type;
 import com.williamcallahan.tui4j.compat.bubbles.spinner.Spinner;
@@ -82,7 +81,6 @@ public class List
     private ListDataSource dataSource;
     private boolean fetchingItems;
     private long totalItems = 0;
-    private int totalPages;
     private long matchedItems = 0;
     private java.util.List<FilteredItem> currentPageItems;
     private ItemDelegate itemDelegate;
@@ -445,7 +443,7 @@ public class List
      */
     public Command select(int index) {
         this.paginator.setPage(index / paginator.perPage());
-        this.cursor = index & paginator.perPage();
+        this.cursor = index % paginator.perPage();
         return fetchCurrentPageItems();
     }
 
@@ -780,7 +778,7 @@ public class List
             keys.showFullHelp().setEnabled(false);
             keys.closeFullHelp().setEnabled(false);
         } else {
-            boolean hasItems = !(totalItems == 0);
+            boolean hasItems = totalItems != 0;
             keys.cursorUp().setEnabled(hasItems);
             keys.cursorDown().setEnabled(hasItems);
             keys.goToStart().setEnabled(hasItems);
@@ -886,20 +884,18 @@ public class List
                 return UpdateResult.from(this, QuitMessage::new);
             }
         } else if (
-            msg instanceof FetchedCurrentPageItems fetchedCurrentPageItems
+            msg instanceof FetchedCurrentPageItems(FetchedItems fetchedItems, Runnable[] postFetchCallbacks)
         ) {
             stopSpinner();
             this.fetchingItems = false;
 
-            FetchedItems fetchedItems = fetchedCurrentPageItems.fetchedItems();
             this.currentPageItems = fetchedItems.items();
             this.matchedItems = fetchedItems.matchedItems();
             this.totalItems = fetchedItems.totalItems();
-            this.totalPages = fetchedItems.totalPages();
 
             updateKeybindings();
 
-            for (Runnable runnable : fetchedCurrentPageItems.postFetch()) {
+            for (Runnable runnable : postFetchCallbacks) {
                 runnable.run();
             }
 
@@ -1015,7 +1011,7 @@ public class List
             this.cursor = 0;
             return;
         }
-        this.cursor = Math.min(this.cursor, this.currentPageItems.size() - 1);
+        this.cursor = Math.clamp(this.cursor, 0, this.currentPageItems.size() - 1);
     }
 
     /**
@@ -1088,7 +1084,7 @@ public class List
                 hideStatusMessage();
 
                 if (totalItems > 0) {
-                    if (!this.currentPageItems.isEmpty()) {
+                    if (this.matchedItems > 0) {
                         filterInput.blur();
                         this.filterState = FilterState.FilterApplied;
                         updateKeybindings();
@@ -1148,10 +1144,10 @@ public class List
             availHeight -= Size.height(pagination);
         }
 
-        String help = null;
+        String helpSection = null;
         if (showHelp) {
-            help = helpView();
-            availHeight -= Size.height(help);
+            helpSection = helpView();
+            availHeight -= Size.height(helpSection);
         }
 
         String content = Style.newStyle()
@@ -1164,7 +1160,7 @@ public class List
         }
 
         if (showHelp) {
-            sections.add(help);
+            sections.add(helpSection);
         }
 
         return VerticalJoinDecorator.joinVertical(
@@ -1354,10 +1350,8 @@ public class List
         );
 
         boolean filtering = filterState == FilterState.Filtering;
-        if (!filtering) {
-            if (itemDelegate instanceof KeyMap delegateKeyMap) {
-                kb.addAll(Arrays.asList(delegateKeyMap.shortHelp()));
-            }
+        if (!filtering && itemDelegate instanceof KeyMap delegateKeyMap) {
+            kb.addAll(Arrays.asList(delegateKeyMap.shortHelp()));
         }
 
         kb.addAll(
@@ -1393,10 +1387,8 @@ public class List
         );
 
         boolean filtering = filterState == FilterState.Filtering;
-        if (!filtering) {
-            if (itemDelegate instanceof KeyMap delegateKeyMap) {
-                kb.addAll(Arrays.asList(delegateKeyMap.fullHelp()));
-            }
+        if (!filtering && itemDelegate instanceof KeyMap delegateKeyMap) {
+            kb.addAll(Arrays.asList(delegateKeyMap.fullHelp()));
         }
 
         java.util.List<Binding> listLevelBindings = new LinkedList<>(

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
@@ -476,13 +476,7 @@ public class List
      * @return selected item or {@code null}
      */
     public Item selectedItem() {
-        int i = index();
-        java.util.List<FilteredItem> visibleItems = visibleItems();
-
-        if (i < 0 || visibleItems.isEmpty() || visibleItems.size() <= i) {
-            return null;
-        }
-        return visibleItems.get(i).item();
+        return this.currentPageItems.get(this.cursor).item();
     }
 
     /**
@@ -843,16 +837,18 @@ public class List
             1,
             availHeight / (itemDelegate.height() + itemDelegate.spacing())
         );
-        paginator.setPerPage(perPage);
-        this.cursor = index % perPage;
 
-        if (paginator.page() >= paginator.totalPages() && paginator.totalPages() > 0) {
-            int newPage = paginator.totalPages() - 1;
-            if (paginator.page() != newPage) {
-                paginator.setPage(newPage);
-                updateKeybindings();
-                return true;
-            }
+        int newCursor = index % perPage;
+        int newPage = (index / perPage);
+
+        paginator.setPerPage(perPage);
+
+        this.cursor = newCursor;
+
+        if (paginator.page() != newPage) {
+            paginator.setPage(newPage);
+            updateKeybindings();
+            return true;
         }
 
         updateKeybindings();
@@ -993,10 +989,7 @@ public class List
     }
 
     private void keepCursorInBounds() {
-        int itemsOnPage = visibleItems().size();
-        if (cursor > itemsOnPage - 1) {
-            this.cursor = Math.max(0, itemsOnPage - 1);
-        }
+        this.cursor = Math.min(this.cursor, this.currentPageItems.size() - 1);
     }
 
     /**
@@ -1005,34 +998,26 @@ public class List
      * @return command to refresh items, or {@code null} if no change
      */
     public Command cursorUp() {
-        this.cursor--;
-        if (cursor < 0) {
-            if (paginator.page() == 0) {
-                if (infiniteScrolling) {
-                    paginator.setPage(paginator.totalPages() - 1);
-                    return fetchCurrentPageItems(() ->
-                        cursor =
-                            paginator.itemsOnPage(visibleItems().size()) - 1
-                    );
-                }
+        if ((cursor - 1) > -1) {
+            this.cursor--;
+            return null;
+        }
 
-                this.cursor = 0;
-                return null;
-            }
-
-            if (infiniteScrolling) {
-                paginator.setPage(paginator.totalPages() - 1);
-                return fetchCurrentPageItems(() ->
-                    cursor = paginator.itemsOnPage(visibleItems().size()) - 1
-                );
-            }
-
+        if (paginator.page() != 0) {
             paginator.prevPage();
             return fetchCurrentPageItems(() ->
-                cursor = visibleItems().size() - 1
+                this.cursor = currentPageItems.size() - 1
             );
         }
-        return null;
+
+        if (!infiniteScrolling) {
+           return null;
+        }
+
+        paginator.setPage(paginator.totalPages() - 1);
+        return fetchCurrentPageItems(() ->
+            cursor = currentPageItems.size() - 1
+        );
     }
 
     /**
@@ -1041,10 +1026,8 @@ public class List
      * @return command to refresh items, or {@code null} if no change
      */
     public Command cursorDown() {
-        int itemsOnPage = visibleItems().size();
-        this.cursor++;
-
-        if (cursor < itemsOnPage) {
+        if ((cursor + 1) < currentPageItems.size()) {
+            this.cursor++;
             return null;
         }
 
@@ -1053,17 +1036,10 @@ public class List
             return fetchCurrentPageItems(() -> cursor = 0);
         }
 
-        if (cursor > itemsOnPage) {
-            this.cursor = 0;
-            return null;
-        }
-
-        this.cursor = itemsOnPage - 1;
-
         if (infiniteScrolling) {
+            paginator.setPage(0);
             return fetchCurrentPageItems(() -> cursor = 0);
         }
-
         return null;
     }
 
@@ -1086,8 +1062,7 @@ public class List
                 hideStatusMessage();
 
                 if (totalItems > 0) {
-                    java.util.List<FilteredItem> h = visibleItems();
-                    if (!h.isEmpty()) {
+                    if (!this.currentPageItems.isEmpty()) {
                         filterInput.blur();
                         this.filterState = FilterState.FilterApplied;
                         updateKeybindings();
@@ -1225,7 +1200,7 @@ public class List
 
     private String statusView() {
         StringBuilder status = new StringBuilder();
-        int visibleItems = visibleItems().size();
+        int visibleItems = this.currentPageItems.size();
 
         String itemName = itemNameSingular;
         if (visibleItems != 1) {
@@ -1309,12 +1284,12 @@ public class List
             return styles.noItems().render("No " + itemNamePlural + ".");
         }
 
-        for (int i = 0; i < items.size(); i++) {
+        for (int i = 0; i < this.currentPageItems.size(); i++) {
             itemDelegate.render(
                 b,
                 this,
                 paginator.page() * paginator.perPage() + i,
-                items.get(i)
+                this.currentPageItems.get(i)
             );
             if (i != items.size() - 1) {
                 b.append("\n".repeat(itemDelegate.spacing() + 1));

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
@@ -476,6 +476,9 @@ public class List
      * @return selected item or {@code null}
      */
     public Item selectedItem() {
+        if (cursor < 0 || currentPageItems.isEmpty() || cursor >= currentPageItems.size()) {
+            return null;
+        }
         return this.currentPageItems.get(this.cursor).item();
     }
 
@@ -818,8 +821,6 @@ public class List
         int index = index();
         int availHeight = this.height;
 
-        paginator.setTotalPages(totalPages);
-
         if (showTitle || (showFilter && filteringEnabled)) {
             availHeight -= Size.height(titleView());
         }
@@ -838,10 +839,17 @@ public class List
             availHeight / (itemDelegate.height() + itemDelegate.spacing())
         );
 
-        int newCursor = index % perPage;
-        int newPage = (index / perPage);
-
         paginator.setPerPage(perPage);
+        int recalculatedTotalPages = calculateTotalPages(perPage);
+        paginator.setTotalPages(recalculatedTotalPages);
+
+        int newCursor = index % perPage;
+        int newPage = 0;
+        if (recalculatedTotalPages > 0) {
+            newPage = Math.min(index / perPage, recalculatedTotalPages - 1);
+        } else {
+            newCursor = 0;
+        }
 
         this.cursor = newCursor;
 
@@ -853,6 +861,20 @@ public class List
 
         updateKeybindings();
         return false;
+    }
+
+    /**
+     * Calculates page count for the current matched-item set and page size.
+     *
+     * @param perPage items per page
+     * @return computed total pages
+     */
+    private int calculateTotalPages(int perPage) {
+        if (matchedItems <= 0) {
+            return 0;
+        }
+        long pages = (matchedItems + perPage - 1) / perPage;
+        return (int) Math.min(pages, Integer.MAX_VALUE);
     }
 
     @Override
@@ -989,6 +1011,10 @@ public class List
     }
 
     private void keepCursorInBounds() {
+        if (currentPageItems.isEmpty()) {
+            this.cursor = 0;
+            return;
+        }
         this.cursor = Math.min(this.cursor, this.currentPageItems.size() - 1);
     }
 
@@ -1200,17 +1226,14 @@ public class List
 
     private String statusView() {
         StringBuilder status = new StringBuilder();
-        int visibleItems = this.currentPageItems.size();
+        long matchedCount = this.matchedItems;
 
-        String itemName = itemNameSingular;
-        if (visibleItems != 1) {
-            itemName = itemNamePlural;
-        }
+        String itemName = matchedCount == 1 ? itemNameSingular : itemNamePlural;
 
-        String itemsDisplay = "%d %s".formatted(matchedItems, itemName);
+        String itemsDisplay = "%d %s".formatted(matchedCount, itemName);
 
         if (filterState == FilterState.Filtering) {
-            if (visibleItems == 0) {
+            if (matchedCount == 0) {
                 status = new StringBuilder(
                     styles.statusEmpty().render("Nothing matched")
                 );
@@ -1237,7 +1260,7 @@ public class List
             filterState == FilterState.Filtering ||
             filterState == FilterState.FilterApplied
         ) {
-            long numFiltered = totalItems - visibleItems;
+            long numFiltered = totalItems - matchedCount;
             if (numFiltered > 0) {
                 status
                     .append(styles.dividerDot().render())
@@ -1273,11 +1296,9 @@ public class List
     }
 
     private String populatedView() {
-        java.util.List<FilteredItem> items = visibleItems();
-
         StringBuilder b = new StringBuilder();
 
-        if (items.isEmpty()) {
+        if (this.matchedItems == 0) {
             if (filterState == FilterState.Filtering) {
                 return "";
             }
@@ -1301,9 +1322,6 @@ public class List
             int emptyLines =
                 (paginator.perPage() - itemsOnPage) *
                 (itemDelegate.height() + itemDelegate.spacing());
-            if (emptyLines == 0) {
-                emptyLines -= itemDelegate.height() - 1; // Edge case adjustment
-            }
             b.append("\n".repeat(emptyLines));
         }
         return b.toString();

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
@@ -1291,17 +1291,17 @@ public class List
                 paginator.page() * paginator.perPage() + i,
                 this.currentPageItems.get(i)
             );
-            if (i != items.size() - 1) {
+            if (i != this.currentPageItems.size() - 1) {
                 b.append("\n".repeat(itemDelegate.spacing() + 1));
             }
         }
 
-        int itemsOnPage = items.size();
+        int itemsOnPage = this.currentPageItems.size();
         if (itemsOnPage < paginator.perPage()) {
             int emptyLines =
                 (paginator.perPage() - itemsOnPage) *
                 (itemDelegate.height() + itemDelegate.spacing());
-            if (items.isEmpty()) {
+            if (emptyLines == 0) {
                 emptyLines -= itemDelegate.height() - 1; // Edge case adjustment
             }
             b.append("\n".repeat(emptyLines));

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
@@ -37,6 +37,8 @@ import java.util.stream.Stream;
 /**
  * Port of Bubbles list.
  * Upstream: bubbles/list/list.go
+ * <p>
+ * Policy references for compat ports: AGENTS.md [JD1a], [JD1b], [FS1g].
  */
 public class List
     implements Model, com.williamcallahan.tui4j.compat.bubbles.help.KeyMap
@@ -438,7 +440,9 @@ public class List
     /**
      * Selects the item at the given index.
      *
-     * @param index absolute item index
+     * The index is zero-based across the full visible sequence, not page-local.
+     *
+     * @param index zero-based absolute item index
      * @return command to refresh items
      */
     public Command select(int index) {
@@ -502,7 +506,12 @@ public class List
     /**
      * Returns the absolute index of the cursor within the full list.
      *
-     * @return absolute cursor index
+     * This index is zero-based and mirrors Bubble's {@code Model.Index()} math
+     * ({@code page * perPage + cursor}) from {@code bubbles/list/list.go}.
+     * <p>
+     * Policy references for compat ports: AGENTS.md [JD1a], [JD1b], [FS1g].
+     *
+     * @return zero-based absolute cursor index
      */
     public int index() {
         return paginator.page() * paginator.perPage() + cursor;
@@ -511,7 +520,9 @@ public class List
     /**
      * Returns the cursor position within the current page.
      *
-     * @return cursor index within the page
+     * Cursor indexes are zero-based within the active page.
+     *
+     * @return zero-based cursor index within the page
      */
     public int cursor() {
         return cursor;
@@ -785,7 +796,7 @@ public class List
             keys.goToEnd().setEnabled(hasItems);
             keys.filter().setEnabled(filteringEnabled && hasItems);
 
-            boolean hasPages = paginator.totalPages() > 0;
+            boolean hasPages = paginator.totalPages() > 1;
             keys.nextPage().setEnabled(hasPages);
             keys.prevPage().setEnabled(hasPages);
             keys
@@ -863,13 +874,17 @@ public class List
 
     /**
      * Calculates page count for the current matched-item set and page size.
+     * <p>
+     * Returns at least {@code 1} to preserve paginator invariants used by
+     * {@code onFirstPage/onLastPage} checks. This matches Bubble's paginator
+     * default/count semantics from {@code bubbles/paginator/paginator.go}.
      *
      * @param perPage items per page
      * @return computed total pages
      */
     private int calculateTotalPages(int perPage) {
         if (matchedItems <= 0) {
-            return 0;
+            return 1;
         }
         long pages = (matchedItems + perPage - 1) / perPage;
         return (int) Math.min(pages, Integer.MAX_VALUE);

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
@@ -1043,7 +1043,7 @@ public class List
         if (paginator.page() != 0) {
             paginator.prevPage();
             return fetchCurrentPageItems(() ->
-                this.cursor = currentPageItems.size() - 1
+                this.cursor = Math.max(0, currentPageItems.size() - 1)
             );
         }
 
@@ -1053,7 +1053,7 @@ public class List
 
         paginator.setPage(paginator.totalPages() - 1);
         return fetchCurrentPageItems(() ->
-            cursor = currentPageItems.size() - 1
+            cursor = Math.max(0, currentPageItems.size() - 1)
         );
     }
 

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/list/List.java
@@ -852,13 +852,8 @@ public class List
         int recalculatedTotalPages = calculateTotalPages(perPage);
         paginator.setTotalPages(recalculatedTotalPages);
 
+        int newPage = Math.min(index / perPage, recalculatedTotalPages - 1);
         int newCursor = index % perPage;
-        int newPage = 0;
-        if (recalculatedTotalPages > 0) {
-            newPage = Math.min(index / perPage, recalculatedTotalPages - 1);
-        } else {
-            newCursor = 0;
-        }
 
         this.cursor = newCursor;
 

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbles/paginator/Paginator.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbles/paginator/Paginator.java
@@ -7,6 +7,11 @@ import com.williamcallahan.tui4j.compat.bubbles.key.Binding;
 /**
  * Port of the Bubble Tea paginator component.
  * Upstream: bubbles/paginator/paginator.go
+ * <p>
+ * Indexing contract: {@code page} is zero-based for internal math while rendered
+ * Arabic output is one-based ({@code page + 1}) for humans.
+ * <p>
+ * Policy references for compat ports: AGENTS.md [JD1a], [JD1b], [FS1g].
  */
 public class Paginator {
 
@@ -130,6 +135,8 @@ public class Paginator {
     /**
      * Returns whether the paginator is on the last page.
      *
+     * This compares a zero-based page index to {@code totalPages - 1}.
+     *
      * @return {@code true} when on the last page
      */
     public boolean onLastPage() {
@@ -138,6 +145,8 @@ public class Paginator {
 
     /**
      * Returns whether the paginator is on the first page.
+     *
+     * The first page index is always {@code 0}.
      *
      * @return {@code true} when on the first page
      */
@@ -193,7 +202,9 @@ public class Paginator {
     /**
      * Returns the total number of pages.
      *
-     * @return total pages
+     * This value is a count, not a zero-based index.
+     *
+     * @return total page count
      */
     public int totalPages() {
         return totalPages;
@@ -220,7 +231,9 @@ public class Paginator {
     /**
      * Sets the current page.
      *
-     * @param page page index
+     * Page indexes are zero-based.
+     *
+     * @param page zero-based page index
      */
     public void setPage(int page) {
         this.page = page;
@@ -229,7 +242,9 @@ public class Paginator {
     /**
      * Returns the current page.
      *
-     * @return page index
+     * Page indexes are zero-based.
+     *
+     * @return zero-based page index
      */
     public int page() {
         return page;
@@ -238,7 +253,9 @@ public class Paginator {
     /**
      * Sets the total number of pages.
      *
-     * @param totalPages total pages
+     * This value is a count, not a zero-based index.
+     *
+     * @param totalPages total page count
      */
     public void setTotalPages(int totalPages) {
         this.totalPages = totalPages;

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbletea/Program.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbletea/Program.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -680,62 +681,64 @@ public class Program {
                 break;
             }
 
-            if (msg != null) {
-                if (filter != null) {
-                    msg = filter.apply(currentModel, msg);
-                }
-                if (msg == null) {
-                    continue;
-                }
-                Message internalMsg = normalizeMessage(msg);
-                Message updateMsg = internalMsg;
+            BiFunction<Model, Message, Message> filter =
+                  Optional.ofNullable(this.filter).orElseGet(() -> (__, message) -> message);
 
-                if (internalMsg instanceof SequencedMessage seqMsg) {
-                    if (seqMsg.sequenceId() < lastHandledSequenceId) {
-                        continue;
-                    }
-                    lastHandledSequenceId = seqMsg.sequenceId();
-                    updateMsg = normalizeMessage(seqMsg.message());
-                    internalMsg = updateMsg;
-                }
+            msg = Optional.ofNullable(msg).map(message -> filter.apply(currentModel, message)).orElse(null);
 
-                if (handleSystemMessage(internalMsg)) {
-                    continue;
-                }
-
-                if (internalMsg instanceof QuitMessage) {
-                    return currentModel;
-                } else if (internalMsg instanceof ErrorMessage errorMessage) {
-                    this.lastError = errorMessage.error();
-                    return currentModel;
-                }
-
-                if (internalMsg instanceof MouseMessage mouseMessage) {
-                    if (mouseSelectionAutoScroller != null) {
-                        mouseSelectionAutoScroller.onMouse(mouseMessage);
-                    }
-                    handleMouseClickTracking(mouseMessage);
-                    handleMouseSelectionTracking(mouseMessage);
-                    handleMouseHoverCursor(mouseMessage);
-                    handleMouseTargetCursor(mouseMessage);
-                }
-
-                // process internal messages for the renderer
-                renderer.handleMessage(internalMsg);
-
-                UpdateResult<? extends Model> updateResult =
-                    currentModel.update(updateMsg);
-
-                currentModel = updateResult.model();
-                renderer.notifyModelChanged();
-                commandExecutor.executeIfPresent(
-                    updateResult.command(),
-                    this::send,
-                    this::sendError
-                );
-
-                renderer.write(currentModel.view());
+            if (msg == null) {
+                continue;
             }
+
+            Message internalMsg = normalizeMessage(msg);
+            Message updateMsg = internalMsg;
+
+            if (internalMsg instanceof SequencedMessage seqMsg) {
+                if (seqMsg.sequenceId() < lastHandledSequenceId) {
+                    continue;
+                }
+                lastHandledSequenceId = seqMsg.sequenceId();
+                updateMsg = normalizeMessage(seqMsg.message());
+                internalMsg = updateMsg;
+            }
+
+            if (handleSystemMessage(internalMsg)) {
+                continue;
+            }
+
+            if (internalMsg instanceof QuitMessage) {
+                return currentModel;
+            } 
+
+            if (internalMsg instanceof ErrorMessage errorMessage) {
+                this.lastError = errorMessage.error();
+                return currentModel;
+            }
+
+            if (internalMsg instanceof MouseMessage mouseMessage) {
+                if (mouseSelectionAutoScroller != null) {
+                    mouseSelectionAutoScroller.onMouse(mouseMessage);
+                }
+                handleMouseClickTracking(mouseMessage);
+                handleMouseSelectionTracking(mouseMessage);
+                handleMouseHoverCursor(mouseMessage);
+            }
+
+            // process internal messages for the renderer
+            renderer.handleMessage(internalMsg);
+
+            UpdateResult<? extends Model> updateResult =
+                currentModel.update(updateMsg);
+
+            currentModel = updateResult.model();
+            renderer.notifyModelChanged();
+            commandExecutor.executeIfPresent(
+                updateResult.command(),
+                this::send,
+                this::sendError
+            );
+
+            renderer.write(currentModel.view());
         }
         return currentModel;
     }

--- a/src/main/java/com/williamcallahan/tui4j/compat/bubbletea/Program.java
+++ b/src/main/java/com/williamcallahan/tui4j/compat/bubbletea/Program.java
@@ -33,7 +33,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -681,10 +680,13 @@ public class Program {
                 break;
             }
 
-            BiFunction<Model, Message, Message> filter =
-                  Optional.ofNullable(this.filter).orElseGet(() -> (__, message) -> message);
+            if (msg == null) {
+                continue;
+            }
 
-            msg = Optional.ofNullable(msg).map(message -> filter.apply(currentModel, message)).orElse(null);
+            if (filter != null) {
+                msg = filter.apply(currentModel, msg);
+            }
 
             if (msg == null) {
                 continue;
@@ -698,6 +700,9 @@ public class Program {
                     continue;
                 }
                 lastHandledSequenceId = seqMsg.sequenceId();
+                if (seqMsg.message() == null) {
+                    continue;
+                }
                 updateMsg = normalizeMessage(seqMsg.message());
                 internalMsg = updateMsg;
             }
@@ -722,6 +727,7 @@ public class Program {
                 handleMouseClickTracking(mouseMessage);
                 handleMouseSelectionTracking(mouseMessage);
                 handleMouseHoverCursor(mouseMessage);
+                handleMouseTargetCursor(mouseMessage);
             }
 
             // process internal messages for the renderer
@@ -1357,7 +1363,9 @@ public class Program {
         }
         try {
             openedInput.close();
-        } catch (IOException ignored) {}
+        } catch (IOException e) {
+            logger.log(Level.FINE, "Failed to close opened input stream", e);
+        }
     }
 
     /**

--- a/src/main/resources/examples/compat/bubbletea/listfancy/Delegate.java
+++ b/src/main/resources/examples/compat/bubbletea/listfancy/Delegate.java
@@ -88,28 +88,37 @@ public class Delegate {
     public static DefaultDelegate newItemDelegate(DelegateKeyMap keyMap) {
         DefaultDelegate defaultDelegate = new DefaultDelegate();
         defaultDelegate.onUpdate((msg, list) -> {
-            if (msg instanceof KeyPressMessage keyPressMessage) {
-                String title = null;
-                int index = -1;
-                if (list.selectedItem() instanceof FancyItem fancyItem && list.dataSource() instanceof DefaultDataSource defaultDataSource) {
-                    index = defaultDataSource.indexOf(fancyItem);
-                    title = fancyItem.title();
-                } else {
-                    return null;
-                }
+            if (!(msg instanceof KeyPressMessage)) {
+               return null;
+            }
 
-                if (Binding.matches(keyPressMessage, keyMap.choose())) {
-                    return list.newStatusMessage(Styles.statusMessageStyle.apply(new String[]{"You choose", title}));
-                } else if (Binding.matches(keyPressMessage, keyMap.remove()) && index != -1) {
-                    return Command.batch(
-                            defaultDataSource.removeItem(index, () -> {
-                                if (defaultDataSource.isEmpty()) {
-                                    keyMap.remove().setEnabled(false);
-                                }
-                            }),
-                            list.newStatusMessage(Styles.statusMessageStyle.apply(new String[]{"Deleted", title}))
-                    );
-                }
+            var keyPressMessage = (KeyPressMessage) msg;
+
+            if (!Binding.matches(keyPressMessage, keyMap.choose(), keyMap.remove())) {
+               return null;
+            }
+
+            String title = null;
+            int index = -1;
+            if (list.selectedItem() instanceof FancyItem fancyItem && list.dataSource() instanceof DefaultDataSource defaultDataSource) {
+                index = defaultDataSource.indexOf(fancyItem);
+                title = fancyItem.title();
+            } else {
+                return null;
+            }
+
+            if (Binding.matches(keyPressMessage, keyMap.choose())) {
+                return list.newStatusMessage(Styles.statusMessageStyle.apply(new String[]{"You choose", title}));
+            } 
+            if (Binding.matches(keyPressMessage, keyMap.remove()) && index != -1) {
+                return Command.batch(
+                        defaultDataSource.removeItem(index, () -> {
+                            if (defaultDataSource.isEmpty()) {
+                                keyMap.remove().setEnabled(false);
+                            }
+                        }),
+                        list.newStatusMessage(Styles.statusMessageStyle.apply(new String[]{"Deleted", title}))
+                );
             }
             return null;
         });

--- a/src/main/resources/examples/compat/bubbletea/listsimple/ListSimpleExample.java
+++ b/src/main/resources/examples/compat/bubbletea/listsimple/ListSimpleExample.java
@@ -148,7 +148,10 @@ public class ListSimpleExample implements Model {
 
         return Command.sequence(listInitCmd, () -> {
             list.setShowStatusBar(false);
-            return null;
+            // no-op
+            return new Message() {
+               
+            };
         });
     }
 
@@ -161,7 +164,7 @@ public class ListSimpleExample implements Model {
     @Override
     public UpdateResult<? extends Model> update(Message msg) {
         if (msg instanceof WindowSizeMessage windowSizeMessage) {
-            return UpdateResult.from(this, list.setWidth(windowSizeMessage.width()));
+            return UpdateResult.from(this, list.setSize(windowSizeMessage.width(), windowSizeMessage.height()));
         }
 
         if (msg instanceof KeyPressMessage keyPressMessage) {

--- a/src/main/resources/examples/compat/bubbletea/listsimple/ListSimpleExample.java
+++ b/src/main/resources/examples/compat/bubbletea/listsimple/ListSimpleExample.java
@@ -148,10 +148,7 @@ public class ListSimpleExample implements Model {
 
         return Command.sequence(listInitCmd, () -> {
             list.setShowStatusBar(false);
-            // no-op
-            return new Message() {
-               
-            };
+            return null;
         });
     }
 

--- a/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
+++ b/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
@@ -181,8 +181,8 @@ class ListTest {
         applyCommand(list, list.select(1));
         applyCommand(list, list.cursorUp());
 
-        assertThat(list.cursor()).isEqualTo(0);
-        assertThat(list.index()).isEqualTo(0);
+        assertThat(list.cursor()).isZero();
+        assertThat(list.index()).isZero();
     }
 
     private static List createList(Item... items) {
@@ -244,20 +244,6 @@ class ListTest {
         }
         if (msg instanceof SequenceMessage sequenceMessage) {
             for (Command c : sequenceMessage.commands()) {
-                applyCommand(list, c);
-            }
-            return;
-        }
-
-        // Also handle the legacy message forms that may be emitted internally.
-        if (msg instanceof com.williamcallahan.tui4j.compat.bubbletea.BatchMessage batchMsg) {
-            for (Command c : batchMsg.commands()) {
-                applyCommand(list, c);
-            }
-            return;
-        }
-        if (msg instanceof com.williamcallahan.tui4j.compat.bubbletea.SequenceMessage sequenceMsg) {
-            for (Command c : sequenceMsg.commands()) {
                 applyCommand(list, c);
             }
             return;

--- a/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
+++ b/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
@@ -143,6 +143,19 @@ class ListTest {
         assertThat(list.filterState()).isEqualTo(FilterState.FilterApplied);
     }
 
+    @Test
+    void testEmptyResultsStayOnSinglePageWithPaginationDisabled() {
+        ListDataSource dataSource = (page, perPage, filterValue) ->
+            new FetchedItems(java.util.List.of(), 0, 0, 0);
+        List list = new List(dataSource, new TestDelegate(), 10, 5);
+        applyCommand(list, list.init());
+
+        assertThat(list.nextPage()).isNull();
+        assertThat(list.prevPage()).isNull();
+        assertThat(keyMap(list).nextPage().isEnabled()).isFalse();
+        assertThat(keyMap(list).prevPage().isEnabled()).isFalse();
+    }
+
     private static List createList(Item... items) {
         List list = new List(items, new TestDelegate(), 10, 10);
         applyCommand(list, list.init());
@@ -244,6 +257,16 @@ class ListTest {
             return (String) method.invoke(list);
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to read populated view", e);
+        }
+    }
+
+    private static KeyMap keyMap(List list) {
+        try {
+            var field = List.class.getDeclaredField("keys");
+            field.setAccessible(true);
+            return (KeyMap) field.get(list);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read key map", e);
         }
     }
 

--- a/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
+++ b/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
@@ -4,6 +4,9 @@ import com.williamcallahan.tui4j.compat.bubbletea.Command;
 import com.williamcallahan.tui4j.compat.bubbletea.BatchMessage;
 import com.williamcallahan.tui4j.compat.bubbletea.Message;
 import com.williamcallahan.tui4j.compat.bubbletea.SequenceMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.KeyPressMessage;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.Key;
+import com.williamcallahan.tui4j.compat.bubbletea.input.key.KeyType;
 import com.williamcallahan.tui4j.compat.lipgloss.Renderer;
 import com.williamcallahan.tui4j.compat.lipgloss.color.ColorProfile;
 import com.williamcallahan.tui4j.compat.lipgloss.color.NoColor;
@@ -91,6 +94,53 @@ class ListTest {
         applyCommand(list, list.setFilterState(FilterState.FilterApplied));
         footer = footerLine(list.view());
         assertThat(footer).contains("clear");
+    }
+
+    @Test
+    void testResizeKeepsAbsoluteSelectionIndex() {
+        Item[] items = new Item[100];
+        for (int i = 0; i < items.length; i++) {
+            items[i] = new TestItem("item-" + i);
+        }
+        List list = createList(items);
+
+        applyCommand(list, list.setShowTitle(false));
+        list.setShowFilter(false);
+        list.setShowStatusBar(false);
+        list.setShowPagination(false);
+        applyCommand(list, list.setShowHelp(false));
+        applyCommand(list, list.refresh());
+
+        applyCommand(list, list.select(80));
+        assertThat(list.index()).isEqualTo(80);
+
+        applyCommand(list, list.setSize(10, 5));
+        assertThat(list.index()).isEqualTo(80);
+        assertThat(list.selectedItem().filterValue()).isEqualTo("item-80");
+    }
+
+    @Test
+    void testPopulatedViewDoesNotShowEmptyStateWhenMatchesExist() {
+        ListDataSource dataSource = (page, perPage, filterValue) ->
+            new FetchedItems(java.util.List.of(), 5, 5, 5);
+        List list = new List(dataSource, new TestDelegate(), 10, 5);
+        applyCommand(list, list.init());
+
+        assertThat(populatedView(list)).doesNotContain("No items.");
+    }
+
+    @Test
+    void testAcceptFilteringUsesMatchedItemsNotCurrentPageSlice() {
+        ListDataSource dataSource = (page, perPage, filterValue) ->
+            new FetchedItems(java.util.List.of(), 3, 5, 1);
+        List list = new List(dataSource, new TestDelegate(), 10, 5);
+        applyCommand(list, list.init());
+        applyCommand(list, list.setFilterText("x"));
+        applyCommand(list, list.setFilterState(FilterState.Filtering));
+
+        applyMessage(list, new KeyPressMessage(new Key(KeyType.keyCR)));
+
+        assertThat(list.filterState()).isEqualTo(FilterState.FilterApplied);
     }
 
     private static List createList(Item... items) {
@@ -184,6 +234,16 @@ class ListTest {
             return (String) method.invoke(list);
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to read status view", e);
+        }
+    }
+
+    private static String populatedView(List list) {
+        try {
+            Method method = List.class.getDeclaredMethod("populatedView");
+            method.setAccessible(true);
+            return (String) method.invoke(list);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read populated view", e);
         }
     }
 

--- a/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
+++ b/src/test/java/com/williamcallahan/tui4j/compat/bubbles/list/ListTest.java
@@ -156,6 +156,35 @@ class ListTest {
         assertThat(keyMap(list).prevPage().isEnabled()).isFalse();
     }
 
+    @Test
+    void testCursorUpFromLaterPageKeepsCursorNonNegativeWhenFetchedPageIsEmpty() {
+        ListDataSource dataSource = (page, perPage, filterValue) -> {
+            if (page == 1) {
+                return new FetchedItems(
+                    java.util.List.of(new FilteredItem(new TestItem("item-1"))),
+                    2,
+                    2,
+                    2
+                );
+            }
+            return new FetchedItems(java.util.List.of(), 2, 2, 2);
+        };
+        List list = new List(dataSource, new TestDelegate(), 10, 5);
+        applyCommand(list, list.init());
+        applyCommand(list, list.setShowTitle(false));
+        list.setShowFilter(false);
+        list.setShowStatusBar(false);
+        list.setShowPagination(false);
+        applyCommand(list, list.setShowHelp(false));
+        applyCommand(list, list.setSize(10, 1));
+
+        applyCommand(list, list.select(1));
+        applyCommand(list, list.cursorUp());
+
+        assertThat(list.cursor()).isEqualTo(0);
+        assertThat(list.index()).isEqualTo(0);
+    }
+
     private static List createList(Item... items) {
         List list = new List(items, new TestDelegate(), 10, 10);
         applyCommand(list, list.init());


### PR DESCRIPTION
# Fix overview
Previously, the available render space was not considered at all. Cursor movements were not accurate, and paging logic was flawed.

# Refactors
Included a small refactor to introduce an early-exit for loop continuation in the main event-loop in `Program` for handling null messages. This change was made to improve readability, no functionality changes are intended. I would certainly not insist that this change be accepted, should this pull request be considered.

# Testing
Since no new functionality was added, no new tests have been added. The previous, incorrect behaviour of the `List` bubble was never directly tested. This is unchanged. It may be wise to add dedicated tests to assert rendering is as expected. I will gladly add these tests on request.

# Bubble example fixes
## `ListSimpleExample`
* Resizing did not consider height; this is fixed.
* `init` emitted a sequenced command that yielded a `null` `Message`. There is currently an intolerance in `Program` for `SequencedMessage`s that wrap a null message. To fix `ListSimpleExample`, I replaced the previous sequenced command with one that emits a non-null, "no-op" message that no model will respect. It may be wise, however, to consider fixing the intolerance of null messages in `SequencedMessage`s in `Program`. I have made no attempt to address this.

## `ListFancyExample`
The `DefaultDelegate` used by `ListFancyExample` was eagerly inspecting selected items on message events that were not relevant to rendering. This exposed the delegate to intermediate, potentially invalid state changes with the `List` instance to which it maintains a reference. After the fix, the delegate only handles messages that directly effect its mandate.

# LLM usage disclosure
No LLM tools whatsoever were used to produce the changes submitted in this pull request. All edits were created and tested manually. Manual testing was conducted using the `ListSimpleExample` and `ListFancyExample` examples.