### PR TITLE
ci: prevent SNAPSHOT releases; publish 0.3.3-SNAPSHOT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,17 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Release version: $VERSION"
 
+      - name: Fail if SNAPSHOT tag
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "::error::Refusing to publish SNAPSHOT version '$VERSION' with the release workflow."
+            echo "::error::Create a non-SNAPSHOT release tag (e.g., v0.3.2) for Maven Central releases."
+            echo "::error::For snapshots, push a -SNAPSHOT version on main and publish via publishAllPublicationsToCentralPortalSnapshots."
+            exit 1
+          fi
+
       - name: Build and test
         run: ./gradlew build examplesClasses -Pversion=${{ steps.version.outputs.VERSION }}
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,44 @@
 implementation 'com.williamcallahan:tui4j:0.3.1-preview'
 ```
 
+### Snapshots
+
+Snapshots are published to Sonatype's snapshot repository (separate from Maven Central releases):
+
+```text
+https://central.sonatype.com/repository/maven-snapshots/
+```
+
+Maven:
+
+```xml
+<repositories>
+    <repository>
+        <id>sonatype-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+</repositories>
+```
+
+Gradle:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
+}
+
+dependencies {
+    implementation("com.williamcallahan:tui4j:0.3.3-SNAPSHOT")
+}
+```
+
 ## Quick Start
 
 TUI4J uses [The Elm Architecture](docs/how-to/tutorial.md): implement a `Model` with `init()`, `update()`, and `view()` methods, then run it with `Program`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@
 
 org.gradle.configuration-cache=true
 group=com.williamcallahan
-version=0.3.1
+version=0.3.3-SNAPSHOT


### PR DESCRIPTION
Fixes Central Portal release failures caused by SNAPSHOT tags and gets snapshot publishing back on track.

Changes:
- Release workflow: fail fast if the release tag ends with -SNAPSHOT (Central releases reject SNAPSHOTs).
- README: document Sonatype snapshot repository usage.
- gradle.properties: bump to 0.3.3-SNAPSHOT so main pushes publish snapshots via publishAllPublicationsToCentralPortalSnapshots.

Verification:
- ./gradlew build examplesClasses (local)
- pre-push hook: ./gradlew test